### PR TITLE
Add usage reset cron job with Vercel and more

### DIFF
--- a/app/404.tsx
+++ b/app/404.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { AlertTriangle } from 'lucide-react'
+
+export default function ForbiddenPage() {
+  const router = useRouter()
+  const [countdown, setCountdown] = useState(5)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prevCount) => {
+        if (prevCount <= 1) {
+          clearInterval(timer)
+          router.push('/')
+        }
+        return prevCount - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-3xl font-bold text-center flex items-center justify-center text-primary">
+            <AlertTriangle className="mr-2 h-8 w-8" />
+            404 Not Found
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-xl mb-4 text-muted-foreground">
+            The page you are looking for does not exist.
+          </p>
+          <p className="text-lg text-secondary-foreground">
+            Redirecting in {countdown} seconds...
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Progress value={(5 - countdown) * 20} className="w-full" />
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+

--- a/app/500.tsx
+++ b/app/500.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { AlertTriangle } from 'lucide-react'
+
+export default function ForbiddenPage() {
+  const router = useRouter()
+  const [countdown, setCountdown] = useState(5)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prevCount) => {
+        if (prevCount <= 1) {
+          clearInterval(timer)
+          router.push('/')
+        }
+        return prevCount - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-3xl font-bold text-center flex items-center justify-center text-primary">
+            <AlertTriangle className="mr-2 h-8 w-8" />
+            5000 Internal Server Error
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-xl mb-4 text-muted-foreground">
+            The server encountered an internal error and was unable to complete your request. Are you authorized to access this page?
+          </p>
+          <p className="text-lg text-secondary-foreground">
+            Redirecting in {countdown} seconds...
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Progress value={(5 - countdown) * 20} className="w-full" />
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+

--- a/app/api/cron/reset-usage/route.ts
+++ b/app/api/cron/reset-usage/route.ts
@@ -1,0 +1,50 @@
+// app/api/cron/reset-usage/route.ts
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+// This endpoint will be called by Vercel Cron
+export async function GET() {
+    try {
+        // Find all active subscriptions that need reset
+        const subscriptions = await prisma.subscription.findMany({
+            where: {
+                status: 'active',
+                currentPeriodEnd: {
+                    // Find subscriptions whose period is ending
+                    lte: new Date()
+                }
+            },
+            include: {
+                FeatureUsage: true
+            }
+        });
+
+        // Reset usage for each subscription
+        for (const subscription of subscriptions) {
+            await prisma.$transaction(async (tx) => {
+                for (const usage of subscription.FeatureUsage) {
+                    await tx.featureUsage.update({
+                        where: { id: usage.id },
+                        data: { currentUsage: 0 }
+                    });
+                }
+            });
+        }
+
+        return NextResponse.json({
+            success: true,
+            processedCount: subscriptions.length
+        });
+    } catch (error) {
+        console.error('Failed to reset usage:', error);
+        return NextResponse.json(
+            { error: 'Failed to reset usage' },
+            { status: 500 }
+        );
+    }
+}

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,17 +1,26 @@
 import { getCurrentCustomer } from '@/lib/payments';
 import { polar } from '@/polar'
-import { redirect, RedirectType } from 'next/navigation';
+import { forbidden, redirect, RedirectType } from 'next/navigation';
 
 export default async function BillingPage() {
     const currentCustomer = await getCurrentCustomer()
 
     if (!currentCustomer) {
-        return <div>No active customer found</div>
+        forbidden()
     }
 
     const session = await polar.customerSessions.create({
         customerId: currentCustomer.customer?.polarCustomerId ?? '',
     });
 
-    redirect("https://sandbox.polar.sh/next-js-payements/portal?customer_session_token=" + session.token, 'push' as RedirectType)
+    const organizationName = (process.env.POLAR_ORGANIZATION_NAME ?? '')
+        .toLowerCase()
+        .replace(/\s+/g, '-');
+
+    const baseUrl = 'https://sandbox.polar.sh';
+    const portalUrl = new URL(`${organizationName}/portal`, baseUrl);
+    portalUrl.searchParams.set('customer_session_token', session.token);
+
+    redirect(portalUrl.toString(), 'push' as RedirectType)
+
 }

--- a/app/forbidden.tsx
+++ b/app/forbidden.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { AlertTriangle } from 'lucide-react'
+
+export default function ForbiddenPage() {
+  const router = useRouter()
+  const [countdown, setCountdown] = useState(5)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prevCount) => {
+        if (prevCount <= 1) {
+          clearInterval(timer)
+          router.push('/')
+        }
+        return prevCount - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-3xl font-bold text-center flex items-center justify-center text-primary">
+            <AlertTriangle className="mr-2 h-8 w-8" />
+            403 Forbidden
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-xl mb-4 text-muted-foreground">
+            You don&apos;t have permission to access this page.
+          </p>
+          <p className="text-lg text-secondary-foreground">
+            Redirecting in {countdown} seconds...
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Progress value={(5 - countdown) * 20} className="w-full" />
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { AlertTriangle } from 'lucide-react'
+
+export default function ForbiddenPage() {
+  const router = useRouter()
+  const [countdown, setCountdown] = useState(5)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prevCount) => {
+        if (prevCount <= 1) {
+          clearInterval(timer)
+          router.push('/')
+        }
+        return prevCount - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-3xl font-bold text-center flex items-center justify-center text-primary">
+            <AlertTriangle className="mr-2 h-8 w-8" />
+            404 Not Found
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-xl mb-4 text-muted-foreground">
+            The page you are looking for does not exist.
+          </p>
+          <p className="text-lg text-secondary-foreground">
+            Redirecting in {countdown} seconds...
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Progress value={(5 - countdown) * 20} className="w-full" />
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
 		config.externals.push("@libsql/client");
 		return config;
 	},
+	experimental: {
+		authInterrupts: true,
+	  },
 };
 
 export default nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [{
+    "path": "/api/cron/reset-usage",
+    "schedule": "0 0 * * *"
+  }]
+}


### PR DESCRIPTION
feat: add automated subscription usage reset via Vercel Cron

- Implement daily usage reset for active subscriptions
- Add /api/cron/reset-usage endpoint for automated resets
- Configure Vercel Cron to run reset job daily at midnight
- Handle reset logic within database transactions for data consistency
- Add error handling and logging for monitoring

This ensures subscription usage limits are automatically reset at the end of each billing period using Vercel's native cron functionality.

Added custom error pages, need to add error page to billing instead of vague 500 error message